### PR TITLE
Set `NUM_THREADS=ALL_CPUS` in all implementations

### DIFF
--- a/c/calculate_ndvi.c
+++ b/c/calculate_ndvi.c
@@ -7,80 +7,80 @@
 
 int main(int argc, char *argv[]) {
     GDALAllRegister();
-    
+
     // Paths to your data
     // const char *nirPath = "../data/T33TTG_20250305T100029_B8A_20m.jp2";
     // const char *redPath = "../data/T33TTG_20250305T100029_B04_20m.jp2";
     const char *nirPath = "../data/T33TTG_20250305T100029_B08_10m.jp2";
     const char *redPath = "../data/T33TTG_20250305T100029_B04_10m.jp2";
     const char *outputPath = "../output/c.tif";
-    
+
     // Open datasets
     GDALDatasetH nirDS = GDALOpen(nirPath, GA_ReadOnly);
     GDALDatasetH redDS = GDALOpen(redPath, GA_ReadOnly);
-    
+
     if (nirDS == NULL || redDS == NULL) {
         fprintf(stderr, "Error: Could not open input datasets\n");
         return 1;
     }
-    
+
     // Get dataset dimensions
     int width = GDALGetRasterXSize(nirDS);
     int height = GDALGetRasterYSize(nirDS);
-    
+
     // Create output dataset
     GDALDriverH driver = GDALGetDriverByName("GTiff");
     // GDALDatasetH outDS = GDALCreate(driver, outputPath, width, height, 1, GDT_Float32, NULL);
-    //with compression 
-    char* options[] = {"COMPRESS=DEFLATE", "TILED=YES", "BIGTIFF=YES", NULL};
+    //with compression
+    char* options[] = {"COMPRESS=DEFLATE", "TILED=YES", "BIGTIFF=YES", "BIGTIFF=YES", "NUM_THREADS=ALL_CPUS", NULL};
     GDALDatasetH outDS = GDALCreate(driver, outputPath, width, height, 1, GDT_Float32, options);
-    
+
     if (outDS == NULL) {
         fprintf(stderr, "Error: Could not create output dataset\n");
         return 1;
     }
-    
+
     // Copy projection and geotransform from input
     GDALSetProjection(outDS, GDALGetProjectionRef(nirDS));
     double geoTransform[6];
     GDALGetGeoTransform(nirDS, geoTransform);
     GDALSetGeoTransform(outDS, geoTransform);
-    
+
     // Allocate memory for raster data
     float *nirBand = (float *)malloc(sizeof(float) * width * height);
     float *redBand = (float *)malloc(sizeof(float) * width * height);
     float *ndviBand = (float *)malloc(sizeof(float) * width * height);
-    
+
     // Read raster data
     GDALRasterBandH nirRasterBand = GDALGetRasterBand(nirDS, 1);
     GDALRasterBandH redRasterBand = GDALGetRasterBand(redDS, 1);
-    
+
     GDALRasterIO(nirRasterBand, GF_Read, 0, 0, width, height, nirBand, width, height, GDT_Float32, 0, 0);
     GDALRasterIO(redRasterBand, GF_Read, 0, 0, width, height, redBand, width, height, GDT_Float32, 0, 0);
-    
+
     // Sentinel-2 data needs to be scaled by 10000 to get reflectance values between 0 and 1
     const float scale = 10000.0;
-    
+
     // Calculate NDVI
     for (int i = 0; i < width * height; i++) {
         // Apply both scale factor and offset: (DN + offset) / scale_factor
         float nir = (nirBand[i] - 1000.0) / scale;
         float red = (redBand[i] - 1000.0) / scale;
-        
+
         if (nir + red > 0) {
             ndviBand[i] = (nir - red) / (nir + red);
         } else {
             ndviBand[i] = -999.0; // NoData value
         }
     }
-    
+
     // Write NDVI to output
     GDALRasterBandH outRasterBand = GDALGetRasterBand(outDS, 1);
     GDALRasterIO(outRasterBand, GF_Write, 0, 0, width, height, ndviBand, width, height, GDT_Float32, 0, 0);
-    
+
     // Set NoData value
     GDALSetRasterNoDataValue(outRasterBand, -999.0);
-    
+
     // Clean up
     free(nirBand);
     free(redBand);
@@ -88,8 +88,8 @@ int main(int argc, char *argv[]) {
     GDALClose(nirDS);
     GDALClose(redDS);
     GDALClose(outDS);
-    
+
     printf("NDVI calculation complete. Output saved to %s\n", outputPath);
-    
+
     return 0;
 }

--- a/rust/src/chunked-parallel-impl.rs
+++ b/rust/src/chunked-parallel-impl.rs
@@ -1,14 +1,14 @@
+use gdal::raster::{Buffer, RasterCreationOption};
 use gdal::Dataset;
 use gdal::DriverManager;
-use gdal::raster::{RasterCreationOption, Buffer};
-use std::path::Path;
-use std::time::Instant;
-use std::sync::Arc;
 use rayon::prelude::*;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let start = Instant::now();
-    
+
     // Path to data
     let granule_path = "../data/";
     // let nir_path = format!("{}T33TTG_20250305T100029_B8A_20m.jp2", granule_path);
@@ -20,48 +20,61 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Constants
     let scale_factor = 10000.0;
     let nodata_value = -999.0;
-    
+
     // Open datasets and preload all data at once
     println!("Opening and loading datasets...");
     let nir_ds = Dataset::open(Path::new(&nir_path))?;
     let red_ds = Dataset::open(Path::new(&red_path))?;
-    
+
     // Get dimensions
     let (width, height) = nir_ds.raster_size();
     println!("Image size: {}x{}", width, height);
-    
+
     // Get bands
     let nir_band = nir_ds.rasterband(1)?;
     let red_band = red_ds.rasterband(1)?;
-    
+
     // Read all data at once
     let nir_data = nir_band.read_as::<f32>(
-        (0, 0), 
+        (0, 0),
         (width as usize, height as usize),
         (width as usize, height as usize),
         None,
     )?;
-    
+
     let red_data = red_band.read_as::<f32>(
-        (0, 0), 
+        (0, 0),
         (width as usize, height as usize),
         (width as usize, height as usize),
         None,
     )?;
-    
+
     // Convert to Arc for efficient sharing
     let nir_vec = Arc::new(nir_data.data);
     let red_vec = Arc::new(red_data.data);
-    
+
     // Create output dataset first
     println!("Creating output dataset...");
     let driver = DriverManager::get_driver_by_name("GTiff")?;
     let options = vec![
-        RasterCreationOption { key: "COMPRESS", value: "DEFLATE" },
-        RasterCreationOption { key: "TILED", value: "YES" },
-        RasterCreationOption { key: "BIGTIFF", value: "YES" },
+        RasterCreationOption {
+            key: "COMPRESS",
+            value: "DEFLATE",
+        },
+        RasterCreationOption {
+            key: "TILED",
+            value: "YES",
+        },
+        RasterCreationOption {
+            key: "BIGTIFF",
+            value: "YES",
+        },
+        RasterCreationOption {
+            key: "NUM_THREADS",
+            value: "ALL_CPUS",
+        },
     ];
-    
+
     let mut out_ds = driver.create_with_band_type_with_options::<f32, _>(
         output_path,
         width as isize,
@@ -69,67 +82,72 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         1,
         &options,
     )?;
-    
+
     // Copy projection and geotransform
     out_ds.set_projection(&nir_ds.projection())?;
     out_ds.set_geo_transform(&nir_ds.geo_transform()?)?;
-    
+
     let mut out_band = out_ds.rasterband(1)?;
     out_band.set_no_data_value(Some(nodata_value))?;
-    
+
     // Calculate NDVI
     println!("Calculating NDVI in parallel chunks...");
-    
+
     // Determine optimal chunk size based on CPU count
-    let num_cpus = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(4);
+    let num_cpus = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4);
     let chunk_height = (height as usize + num_cpus - 1) / num_cpus;
-    
+
     // Process chunks sequentially but process pixels in each chunk in parallel
     for chunk_start in (0..height as usize).step_by(chunk_height) {
         let actual_chunk_height = std::cmp::min(chunk_height, height as usize - chunk_start);
         let start_idx = chunk_start * width as usize;
         let end_idx = start_idx + actual_chunk_height * width as usize;
-        
+
         let nir_vec = Arc::clone(&nir_vec);
         let red_vec = Arc::clone(&red_vec);
-        
+
         // Create result buffer for this chunk
         let mut ndvi_chunk = vec![0.0f32; actual_chunk_height * width as usize];
-        
+
         // Calculate NDVI for each pixel in the chunk (in parallel)
         ndvi_chunk.par_iter_mut().enumerate().for_each(|(i, ndvi)| {
             let global_idx = start_idx + i;
             // Apply both scale factor and offset: (DN + offset) / scale_factor
             let nir = (nir_vec[global_idx] - 1000.0) / scale_factor as f32;
             let red = (red_vec[global_idx] - 1000.0) / scale_factor as f32;
-            
+
             *ndvi = if nir + red > 0.0 {
                 (nir - red) / (nir + red)
             } else {
                 nodata_value as f32
             };
         });
-        
+
         // Write this chunk
-        let band_data = Buffer::new(
-            (width as usize, actual_chunk_height),
-            ndvi_chunk
-        );
-        
+        let band_data = Buffer::new((width as usize, actual_chunk_height), ndvi_chunk);
+
         out_band.write(
-            (0, chunk_start as isize), 
+            (0, chunk_start as isize),
             (width as usize, actual_chunk_height),
-            &band_data
+            &band_data,
         )?;
-        
-        println!("Processed chunk at y={}, {:.1}% complete", 
-                 chunk_start, (chunk_start as f64 + actual_chunk_height as f64) / height as f64 * 100.0);
+
+        println!(
+            "Processed chunk at y={}, {:.1}% complete",
+            chunk_start,
+            (chunk_start as f64 + actual_chunk_height as f64) / height as f64 * 100.0
+        );
     }
-    
+
     // Flush and close
     out_ds.flush_cache()?;
-    
-    println!("NDVI calculation complete in {:.3}s", start.elapsed().as_secs_f64());
-    
+
+    println!(
+        "NDVI calculation complete in {:.3}s",
+        start.elapsed().as_secs_f64()
+    );
+
     Ok(())
 }

--- a/rust/src/direct-gdal-impl.rs
+++ b/rust/src/direct-gdal-impl.rs
@@ -1,9 +1,9 @@
-use std::os::raw::{c_int, c_char, c_double};
-use std::ffi::{CString, CStr};
-use std::ptr;
-use std::time::Instant;
-use std::slice;
 use rayon::prelude::*;
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_double, c_int};
+use std::ptr;
+use std::slice;
+use std::time::Instant;
 
 // FFI bindings to GDAL C API
 #[allow(non_camel_case_types)]
@@ -22,16 +22,28 @@ extern "C" {
     fn GDALGetRasterYSize(hDS: GDALDatasetH) -> c_int;
     fn GDALGetRasterBand(hDS: GDALDatasetH, nBandId: c_int) -> GDALRasterBandH;
     fn GDALRasterIO(
-        hBand: GDALRasterBandH, eRWFlag: c_int, nXOff: c_int, nYOff: c_int,
-        nXSize: c_int, nYSize: c_int, pData: *mut libc::c_void,
-        nBufXSize: c_int, nBufYSize: c_int, eBufType: c_int,
-        nPixelSpace: c_int, nLineSpace: c_int
+        hBand: GDALRasterBandH,
+        eRWFlag: c_int,
+        nXOff: c_int,
+        nYOff: c_int,
+        nXSize: c_int,
+        nYSize: c_int,
+        pData: *mut libc::c_void,
+        nBufXSize: c_int,
+        nBufYSize: c_int,
+        eBufType: c_int,
+        nPixelSpace: c_int,
+        nLineSpace: c_int,
     ) -> c_int;
     fn GDALGetDriverByName(pszName: *const c_char) -> GDALDriverH;
     fn GDALCreate(
-        hDriver: GDALDriverH, pszFilename: *const c_char,
-        nXSize: c_int, nYSize: c_int, nBands: c_int,
-        eType: c_int, papszOptions: *const *const c_char
+        hDriver: GDALDriverH,
+        pszFilename: *const c_char,
+        nXSize: c_int,
+        nYSize: c_int,
+        nBands: c_int,
+        eType: c_int,
+        papszOptions: *const *const c_char,
     ) -> GDALDatasetH;
     fn GDALSetRasterNoDataValue(hBand: GDALRasterBandH, dfNoData: c_double) -> c_int;
     fn GDALGetProjectionRef(hDS: GDALDatasetH) -> *const c_char;
@@ -53,7 +65,7 @@ const GF_Write: c_int = 1;
 
 fn main() {
     let start = Instant::now();
-    
+
     // Path to data
     let granule_path = "../data/";
     // let nir_path = format!("{}T33TTG_20250305T100029_B8A_20m.jp2", granule_path);
@@ -61,52 +73,57 @@ fn main() {
     let nir_path = format!("{}T33TTG_20250305T100029_B08_10m.jp2", granule_path);
     let red_path = format!("{}T33TTG_20250305T100029_B04_10m.jp2", granule_path);
     let output_path = "../output/rust_direct_gdal.tif";
-    
+
     // Constants
     let scale_factor = 10000.0;
     let nodata_value = -999.0;
-    
+
     // Initialize GDAL
     unsafe {
         GDALAllRegister();
-        
+
         // Open input datasets
         println!("Opening datasets...");
         let nir_c_path = CString::new(nir_path).unwrap();
         let red_c_path = CString::new(red_path).unwrap();
         let nir_ds = GDALOpen(nir_c_path.as_ptr(), GA_ReadOnly);
         let red_ds = GDALOpen(red_c_path.as_ptr(), GA_ReadOnly);
-        
+
         if nir_ds.is_null() || red_ds.is_null() {
             panic!("Failed to open input datasets");
         }
-        
+
         // Get dimensions
         let width = GDALGetRasterXSize(nir_ds);
         let height = GDALGetRasterYSize(nir_ds);
         println!("Image size: {}x{}", width, height);
-        
+
         // Get bands
         let nir_band = GDALGetRasterBand(nir_ds, 1);
         let red_band = GDALGetRasterBand(red_ds, 1);
-        
+
         // Create output dataset
         println!("Creating output dataset...");
         let driver_name = CString::new("GTiff").unwrap();
         let driver = GDALGetDriverByName(driver_name.as_ptr());
-        
+
         if driver.is_null() {
             panic!("Failed to get GTiff driver");
         }
-        
+
         // Create options for GTiff driver
         let option1 = CString::new("COMPRESS=DEFLATE").unwrap();
         let option2 = CString::new("TILED=YES").unwrap();
         let option3 = CString::new("BIGTIFF=YES").unwrap();
         let option4 = CString::new("NUM_THREADS=ALL_CPUS").unwrap();
-        let mut options = vec![option1.as_ptr(), option2.as_ptr(), option3.as_ptr(), option4.as_ptr()];
+        let mut options = vec![
+            option1.as_ptr(),
+            option2.as_ptr(),
+            option3.as_ptr(),
+            option4.as_ptr(),
+        ];
         options.push(ptr::null());
-        
+
         let output_c_path = CString::new(output_path).unwrap();
         let out_ds = GDALCreate(
             driver,
@@ -117,32 +134,32 @@ fn main() {
             GDT_Float32,
             options.as_ptr(),
         );
-        
+
         if out_ds.is_null() {
             panic!("Failed to create output dataset");
         }
-        
+
         // Copy projection and geotransform
         let projection = GDALGetProjectionRef(nir_ds);
         if !projection.is_null() {
             GDALSetProjection(out_ds, projection);
         }
-        
+
         let mut transform: [c_double; 6] = [0.0; 6];
         if GDALGetGeoTransform(nir_ds, transform.as_mut_ptr()) == 0 {
             GDALSetGeoTransform(out_ds, transform.as_ptr());
         }
-        
+
         let out_band = GDALGetRasterBand(out_ds, 1);
         GDALSetRasterNoDataValue(out_band, nodata_value);
-        
+
         // Calculate NDVI in chunks for memory efficiency
         println!("Calculating NDVI...");
-        
+
         let num_cpus = std::thread::available_parallelism()
             .map(|n| n.get() as i32)
             .unwrap_or(4);
-        
+
         let chunk_height = 2048; // Use fixed chunk size for better results
         let total_pixels_per_chunk = (width * chunk_height) as usize;
 
@@ -150,55 +167,88 @@ fn main() {
         for y_offset in (0..height).step_by(chunk_height as usize) {
             let actual_height = std::cmp::min(chunk_height, height - y_offset);
             let total_pixels = (width * actual_height) as usize;
-            
+
             // Read NIR band data
             let mut nir_data = vec![0.0f32; total_pixels];
             GDALRasterIO(
-                nir_band, GF_Read, 0, y_offset, width, actual_height,
+                nir_band,
+                GF_Read,
+                0,
+                y_offset,
+                width,
+                actual_height,
                 nir_data.as_mut_ptr() as *mut libc::c_void,
-                width, actual_height, GDT_Float32, 0, 0
+                width,
+                actual_height,
+                GDT_Float32,
+                0,
+                0,
             );
-            
+
             // Read RED band data
             let mut red_data = vec![0.0f32; total_pixels];
             GDALRasterIO(
-                red_band, GF_Read, 0, y_offset, width, actual_height,
+                red_band,
+                GF_Read,
+                0,
+                y_offset,
+                width,
+                actual_height,
                 red_data.as_mut_ptr() as *mut libc::c_void,
-                width, actual_height, GDT_Float32, 0, 0
+                width,
+                actual_height,
+                GDT_Float32,
+                0,
+                0,
             );
-            
+
             // Allocate output array
             let mut ndvi_data = vec![0.0f32; total_pixels];
-            
+
             // Calculate NDVI in parallel
             ndvi_data.par_iter_mut().enumerate().for_each(|(i, ndvi)| {
                 // Apply both scale factor and offset: (DN + offset) / scale_factor
                 let nir = (nir_data[i] - 1000.0) / scale_factor as f32;
                 let red = (red_data[i] - 1000.0) / scale_factor as f32;
-                
+
                 *ndvi = if nir + red > 0.0 {
                     (nir - red) / (nir + red)
                 } else {
                     nodata_value as f32
                 };
             });
-            
+
             // Write result
             GDALRasterIO(
-                out_band, GF_Write, 0, y_offset, width, actual_height,
+                out_band,
+                GF_Write,
+                0,
+                y_offset,
+                width,
+                actual_height,
                 ndvi_data.as_mut_ptr() as *mut libc::c_void,
-                width, actual_height, GDT_Float32, 0, 0
+                width,
+                actual_height,
+                GDT_Float32,
+                0,
+                0,
             );
-            
-            println!("Processed chunk at y={}, {:.1}% complete",
-                     y_offset, (y_offset as f64 + actual_height as f64) / height as f64 * 100.0);
+
+            println!(
+                "Processed chunk at y={}, {:.1}% complete",
+                y_offset,
+                (y_offset as f64 + actual_height as f64) / height as f64 * 100.0
+            );
         }
-        
+
         // Clean up
         GDALClose(out_ds);
         GDALClose(nir_ds);
         GDALClose(red_ds);
     }
-    
-    println!("NDVI calculation complete in {:.3}s", start.elapsed().as_secs_f64());
+
+    println!(
+        "NDVI calculation complete in {:.3}s",
+        start.elapsed().as_secs_f64()
+    );
 }

--- a/rust/src/manual_optimized.rs
+++ b/rust/src/manual_optimized.rs
@@ -1,57 +1,70 @@
+use gdal::raster::{Buffer, RasterCreationOption};
 use gdal::Dataset;
 use gdal::DriverManager;
-use gdal::raster::{RasterCreationOption, Buffer};
+use rayon::prelude::*;
 use std::path::Path;
 use std::time::Instant;
-use rayon::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let start = Instant::now();
-    
+
     // Path to data
     let granule_path = "../data/";
     let nir_path = format!("{}T33TTG_20250305T100029_B08_10m.jp2", granule_path);
     let red_path = format!("{}T33TTG_20250305T100029_B04_10m.jp2", granule_path);
     let output_path = "../output/rust_optimized.tif";
-    
+
     // Open datasets
     println!("Opening datasets...");
     let nir_ds = Dataset::open(Path::new(&nir_path))?;
     let red_ds = Dataset::open(Path::new(&red_path))?;
-    
+
     // Get dimensions
     let (width, height) = nir_ds.raster_size();
     println!("Image size: {}x{}", width, height);
-    
+
     // Get bands
     let nir_band = nir_ds.rasterband(1)?;
     let red_band = red_ds.rasterband(1)?;
-    
+
     // Read the entire image at once
     println!("Reading entire image...");
     let nir_data = nir_band.read_as::<f32>(
-        (0, 0), 
+        (0, 0),
         (width as usize, height as usize),
         (width as usize, height as usize),
         None,
     )?;
-    
+
     let red_data = red_band.read_as::<f32>(
-        (0, 0), 
+        (0, 0),
         (width as usize, height as usize),
         (width as usize, height as usize),
         None,
     )?;
-    
+
     // Create output dataset
     println!("Creating output dataset...");
     let driver = DriverManager::get_driver_by_name("GTiff")?;
     let options = vec![
-        RasterCreationOption { key: "COMPRESS", value: "DEFLATE" },
-        RasterCreationOption { key: "TILED", value: "YES" },
-        RasterCreationOption { key: "BIGTIFF", value: "YES" },
+        RasterCreationOption {
+            key: "COMPRESS",
+            value: "DEFLATE",
+        },
+        RasterCreationOption {
+            key: "TILED",
+            value: "YES",
+        },
+        RasterCreationOption {
+            key: "BIGTIFF",
+            value: "YES",
+        },
+        RasterCreationOption {
+            key: "NUM_THREADS",
+            value: "ALL_CPUS",
+        },
     ];
-    
+
     let mut out_ds = driver.create_with_band_type_with_options::<f32, _>(
         output_path,
         width as isize,
@@ -59,53 +72,54 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         1,
         &options,
     )?;
-    
+
     // Copy projection and geotransform
     out_ds.set_projection(&nir_ds.projection())?;
     out_ds.set_geo_transform(&nir_ds.geo_transform()?)?;
-    
+
     let mut out_band = out_ds.rasterband(1)?;
     let nodata_value = -999.0;
     out_band.set_no_data_value(Some(nodata_value))?;
-    
+
     // Calculate NDVI using optimized approach
     println!("Calculating NDVI...");
     let nir_vec = nir_data.data;
     let red_vec = red_data.data;
     let scale_factor = 10000.0f32;
-    
+
     // Create result buffer
     let mut ndvi_vec = vec![0.0f32; width as usize * height as usize];
-    
+
     // Process in larger chunks (cache-friendly)
     const CHUNK_SIZE: usize = 4096;
-    
+
     // Configure workload with better distribution
     let num_threads = rayon::current_num_threads();
     let total_pixels = nir_vec.len();
     let pixels_per_thread = (total_pixels + num_threads - 1) / num_threads;
-    
+
     // Process in parallel with optimal chunk sizes
-    ndvi_vec.par_chunks_mut(pixels_per_thread)
+    ndvi_vec
+        .par_chunks_mut(pixels_per_thread)
         .enumerate()
         .for_each(|(chunk_id, ndvi_chunk)| {
             let start = chunk_id * pixels_per_thread;
             let end = std::cmp::min(start + pixels_per_thread, total_pixels);
-            
+
             // Process each block in this chunk
             for block_start in (start..end).step_by(CHUNK_SIZE) {
                 let block_end = std::cmp::min(block_start + CHUNK_SIZE, end);
                 let block_size = block_end - block_start;
-                
+
                 // Process this block
                 for i in 0..block_size {
                     let global_idx = block_start + i;
                     let local_idx = i;
-                    
+
                     // Compute NDVI
                     let nir = (nir_vec[global_idx] - 1000.0) / scale_factor;
                     let red = (red_vec[global_idx] - 1000.0) / scale_factor;
-                    
+
                     ndvi_chunk[local_idx] = if nir + red > 0.0 {
                         (nir - red) / (nir + red)
                     } else {
@@ -114,18 +128,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
         });
-    
+
     // Write the entire result at once
     println!("Writing result...");
-    let band_data = Buffer::new(
-        (width as usize, height as usize),
-        ndvi_vec
-    );
-    
+    let band_data = Buffer::new((width as usize, height as usize), ndvi_vec);
+
     out_band.write((0, 0), (width as usize, height as usize), &band_data)?;
-    
+
     out_ds.flush_cache()?;
-    println!("NDVI calculation complete in {:.3}s", start.elapsed().as_secs_f64());
-    
+    println!(
+        "NDVI calculation complete in {:.3}s",
+        start.elapsed().as_secs_f64()
+    );
+
     Ok(())
 }


### PR DESCRIPTION
There's no reason for the C and Rust versions to behave so differently.

Sorry for the formatting changes, but in Rust has a good auto-formatter and it's pretty common to run it. https://github.com/ominiverdi/spectral-calc-tests/pull/5/files?w=1 should be easier to read.